### PR TITLE
consume parameters given in the POST request body

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -111,15 +111,28 @@ class Application(implicit val executionContext: ExecutionContext,
     config.as[FiniteDuration]("OAuth2.pendingConsentTimeout")
   lazy val disableConsent = config.as[Boolean]("OAuth2.disableConsent")
 
-  def accessToken(maybeGrantType: Option[String],
-                  maybeScope: Option[String],
-                  maybeUsername: Option[String],
-                  maybePassword: Option[String],
-                  maybeCode: Option[String],
-                  maybeClientId: Option[String],
-                  maybeClientSecret: Option[String],
-                  maybeRedirectUri: Option[String]) = {
-    Action {
+  val accessTokenForm = Form(
+    tuple(
+      "grant_type" -> optional(text),
+      "scope" -> optional(text),
+      "username" -> optional(text),
+      "password" -> optional(text),
+      "code" -> optional(text),
+      "client_id" -> optional(text),
+      "client_secret" -> optional(text),
+      "redirect_uri" -> optional(text)
+    )
+  )
+  def accessToken = {
+    Action {implicit request =>
+      val (maybeGrantType: Option[String],
+          maybeScope: Option[String],
+          maybeUsername: Option[String],
+          maybePassword: Option[String],
+          maybeCode: Option[String],
+          maybeClientId: Option[String],
+          maybeClientSecret: Option[String],
+          maybeRedirectUri: Option[String]) = accessTokenForm.bindFromRequest.get
       maybeGrantType match {
         case Some("authorization_code") =>
           val params = for {

--- a/conf/routes
+++ b/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 # Home page
-POST          /access_token        controllers.Application.accessToken(grant_type: Option[String], scope: Option[String], username: Option[String], password: Option[String], code: Option[String], client_id: Option[String],client_secret: Option[String] ,redirect_uri: Option[String])
+POST          /access_token        controllers.Application.accessToken
 GET           /authorize           controllers.Application.authorize(state: Option[String], redirect_uri: Option[String], response_type: Option[String], client_id: Option[String], scope: Option[String])
 POST          /accept              controllers.Application.accept()
 POST          /login               controllers.Application.login()


### PR DESCRIPTION
At the endpoint /access_token there is a POST request expected. But the way it was implemented only GET-paramters are consumed, so it only worked is you send a POST request with GET parameters. With this patch POST parameters are also processed
