### PR TITLE
HTTP Basic authentication for client_id / client_secret

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,8 +1,6 @@
 package controllers
 
 import java.time.LocalDateTime
-import java.time.Duration
-import java.util.concurrent._
 import sun.misc.BASE64Decoder
 
 import cats.data.Xor

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,6 +1,9 @@
 package controllers
 
 import java.time.LocalDateTime
+import java.time.Duration
+import java.util.concurrent._
+import sun.misc.BASE64Decoder
 
 import cats.data.Xor
 import com.typesafe.config.{Config, ConfigException}
@@ -75,6 +78,28 @@ class Application(implicit val executionContext: ExecutionContext,
     }
   }
 
+  private def decodeBasicAuth(auth: String): Option[(String, String)] = {
+    lazy val basicSt = "basic "
+
+    if (auth.length() < basicSt.length()) {
+      return None
+    }
+    val basicReqSt = auth.substring(0, basicSt.length())
+    if (basicReqSt.toLowerCase() != basicSt) {
+      return None
+    }
+    val basicAuthSt = auth.replaceFirst(basicReqSt, "")
+    //BESE64Decoder is not thread safe, don't make it a field of this object
+    val decoder = new BASE64Decoder()
+    val decodedAuthSt = new String(decoder.decodeBuffer(basicAuthSt), "UTF-8")
+    val usernamePassword = decodedAuthSt.split(":")
+    if (usernamePassword.length >= 2) {
+      //account for ":" in passwords
+      return Some((usernamePassword(0), usernamePassword.splitAt(1)._2.mkString(":")))
+    }
+    None
+  }
+
   implicit val clientCredentialsValueReader =
     new ValueReader[ClientCredential] {
       def read(config: Config, path: String): ClientCredential = {
@@ -133,6 +158,7 @@ class Application(implicit val executionContext: ExecutionContext,
           maybeClientId: Option[String],
           maybeClientSecret: Option[String],
           maybeRedirectUri: Option[String]) = accessTokenForm.bindFromRequest.get
+      val auth = request.headers.get("authorization").flatMap(decodeBasicAuth)
       maybeGrantType match {
         case Some("authorization_code") =>
           val params = for {
@@ -141,13 +167,19 @@ class Application(implicit val executionContext: ExecutionContext,
                        UnprocessableEntity(
                            views.Application.error("Missing code")))
             clientId <- Xor.fromOption(
-                           maybeClientId,
-                           UnprocessableEntity(
-                               views.Application.error("Missing client_id")))
+                        maybeClientId orElse auth match {
+                            case Some((clientId, clientSecret)) => Some(clientId)
+                            case _ => None
+                        },
+                        UnprocessableEntity(views.Application.error(
+                              "Missing client_id")))
             clientSecret <- Xor.fromOption(
-                               maybeClientSecret,
-                               UnprocessableEntity(views.Application.error(
-                                       "Missing client_secret")))
+                    maybeClientSecret orElse auth match {
+                      case Some((clientId, clientSecret)) => Some(clientSecret)
+                      case _ => None
+                    },
+                    UnprocessableEntity(views.Application.error(
+                          "Missing client_secret")))
             redirectUri <- Xor.fromOption(
                               maybeRedirectUri,
                               UnprocessableEntity(views.Application.error(
@@ -221,13 +253,19 @@ class Application(implicit val executionContext: ExecutionContext,
         case Some("client_credentials") =>
           val params = for {
             clientId <- Xor.fromOption(
-                           maybeClientId,
-                           UnprocessableEntity(
-                               views.Application.error("Missing client_id")))
+                    maybeClientId orElse auth match {
+                        case Some((clientId, clientSecret)) => Some(clientId)
+                        case _ => None
+                    },
+                    UnprocessableEntity(
+                        views.Application.error("Missing client_id")))
             clientSecret <- Xor.fromOption(
-                               maybeClientSecret,
-                               UnprocessableEntity(views.Application.error(
-                                       "Missing client_secret")))
+                    maybeClientSecret orElse auth match {
+                      case Some((clientId, clientSecret)) => Some(clientSecret)
+                      case _ => None
+                    },
+                    UnprocessableEntity(views.Application.error(
+                            "Missing client_secret")))
             find <- Xor.fromOption(
                        clients.find(_.clientId == clientId),
                        UnprocessableEntity(
@@ -272,15 +310,19 @@ class Application(implicit val executionContext: ExecutionContext,
                            UnprocessableEntity(
                                views.Application.error("Missing password")))
             clientId <- Xor.fromOption(
-                           maybeClientId,
-                           UnprocessableEntity(
-                               views.Application.error("Missing client_id"))
-                       )
+                      maybeClientId orElse auth match {
+                          case Some((clientId, clientSecret)) => Some(clientId)
+                          case _ => None
+                      },
+                      UnprocessableEntity(
+                          views.Application.error("Missing client_id")))
             clientSecret <- Xor.fromOption(
-                               maybeClientSecret,
-                               UnprocessableEntity(views.Application.error(
-                                       "Missing client_id"))
-                           )
+                        maybeClientSecret orElse auth match {
+                          case Some((clientId, clientSecret)) => Some(clientSecret)
+                          case _ => None
+                        },
+                       UnprocessableEntity(views.Application.error(
+                               "Missing client_id")))
             checkClientId <- {
               Xor.fromOption(clients.find(_.clientId == clientId),
                              UnprocessableEntity(

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -111,15 +111,28 @@ class Application(implicit val executionContext: ExecutionContext,
     config.as[FiniteDuration]("OAuth2.pendingConsentTimeout")
   lazy val disableConsent = config.as[Boolean]("OAuth2.disableConsent")
 
-  def accessToken(maybeGrantType: Option[String],
-                  maybeScope: Option[String],
-                  maybeUsername: Option[String],
-                  maybePassword: Option[String],
-                  maybeCode: Option[String],
-                  maybeClientId: Option[String],
-                  maybeClientSecret: Option[String],
-                  maybeRedirectUri: Option[String]) = {
-    Action {
+  val accessTokenForm = Form(
+    tuple(
+      "grant_type" -> optional(text),
+      "scope" -> optional(text),
+      "username" -> optional(text),
+      "password" -> optional(text),
+      "code" -> optional(text),
+      "client_id" -> optional(text),
+      "client_secret" -> optional(text),
+      "redirect_uri" -> optional(text)
+    )
+  )
+  def accessToken = {
+    Action {implicit request =>
+      val (maybeGrantType: Option[String],
+          maybeScope: Option[String],
+          maybeUsername: Option[String],
+          maybePassword: Option[String],
+          maybeCode: Option[String],
+          maybeClientId: Option[String],
+          maybeClientSecret: Option[String],
+          maybeRedirectUri: Option[String]) = accessTokenForm.bindFromRequest.get
       maybeGrantType match {
         case Some("authorization_code") =>
           val params = for {

--- a/conf/routes
+++ b/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 # Home page
-POST          /access_token        controllers.Application.accessToken(grant_type: Option[String], scope: Option[String], username: Option[String], password: Option[String], code: Option[String], client_id: Option[String],client_secret: Option[String] ,redirect_uri: Option[String])
+POST          /access_token        controllers.Application.accessToken
 GET           /authorize           controllers.Application.authorize(state: Option[String], redirect_uri: Option[String], response_type: Option[String], client_id: Option[String], scope: Option[String])
 POST          /accept              controllers.Application.accept()
 POST          /login               controllers.Application.login()


### PR DESCRIPTION
Accept client_id and client_secret also as HTTP Basic authentication header as described in https://tools.ietf.org/html/rfc6749#section-2.3.1
